### PR TITLE
bugfix: index out of range

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint": "yarn run eslint . -- --fix && yarn lint:sol",
     "compile": "rm -rf ./build/* && truffle compile",
     "clean": "rm -rf ./build/* && yarn truffle networks --clean",
-    "rpc": "yarn run testrpc -a 3 -i 10 -u 0 -u 1 -u 3",
+    "rpc": "yarn run testrpc -a 3 -i 10 -u 0 -u 1 -u 2",
     "deploy": "yarn run clean && yarn truffle compile && truffle deploy --network development"
   }
 }


### PR DESCRIPTION
The command `testrpc -a 3` will create three accounts at startup, so the maximal index of accounts is 2 instead of 3